### PR TITLE
Add api metadata yaml support for auto documentation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ This is required to have maven build a "fat," executable jar file.
 
 	# dropwizard-spring sample service configuration
 
+	# High level information that describes the application. This can be pulled into auto documentation tools like Swagger.
+	apiMetadata:
+    	rootServerName: www.someshop.zzz
+    	title: My Online Shop
+    	description: Configure and use the online shop via this API
+    	contact: developers@someshop
+    	license: Licence type here
+    	licenseUrl: http://urltolicence.zzz
+    	termsOfServiceUrl: http://urltotos.zzz 
+
 	spring:
 
         # Spring Context Type (Required)

--- a/README.md
+++ b/README.md
@@ -75,14 +75,14 @@ This is required to have maven build a "fat," executable jar file.
 
 	# High level information that describes the application. This can be pulled into auto documentation tools like Swagger.
 	apiMetadata:
-    	rootServerName: www.someshop.zzz
-    	title: My Online Shop
-    	description: Configure and use the online shop via this API
-    	contact: developers@someshop
-    	license: Licence type here
-    	licenseUrl: http://urltolicence.zzz
-    	termsOfServiceUrl: http://urltotos.zzz 
-
+	    rootServerName: www.someshop.zzz
+	    title: My Online Shop
+	    description: Configure and use the online shop via this API
+	    contact: developers@someshop
+	    license: Licence type here
+	    licenseUrl: http://urltolicence.zzz
+	    termsOfServiceUrl: http://urltotos.zzz
+	
 	spring:
 
         # Spring Context Type (Required)

--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ This is required to have maven build a "fat," executable jar file.
 
 	# High level information that describes the application. This can be pulled into auto documentation tools like Swagger.
 	apiMetadata:
-	    rootServerName: www.someshop.zzz
-	    title: My Online Shop
-	    description: Configure and use the online shop via this API
-	    contact: developers@someshop
-	    license: Licence type here
-	    licenseUrl: http://urltolicence.zzz
-	    termsOfServiceUrl: http://urltotos.zzz
+	    rootServerName: www.example.com
+	    title: My Example Application
+	    description: Configure and use the application via this API
+	    contact: developers@example.com
+	    license: License type here
+	    licenseUrl: http://www.example.com/license
+	    termsOfServiceUrl: http://www.example.com/tos
 	
 	spring:
 

--- a/src/main/java/com/hmsonline/dropwizard/spring/ApiMetadata.java
+++ b/src/main/java/com/hmsonline/dropwizard/spring/ApiMetadata.java
@@ -1,0 +1,66 @@
+package com.hmsonline.dropwizard.spring;
+
+import org.hibernate.validator.constraints.NotEmpty;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.yammer.dropwizard.config.Configuration;
+
+public class ApiMetadata extends Configuration {
+
+    @NotEmpty
+    @JsonProperty
+    private String rootServerName = "localhost";
+    
+    @NotEmpty
+    @JsonProperty
+    private String title = "";
+    
+    @NotEmpty
+    @JsonProperty
+    private String description = "";
+    
+    @NotEmpty
+    @JsonProperty
+    private String termsOfServiceUrl = "";
+    
+    @NotEmpty
+    @JsonProperty
+    private String contact = "";
+    
+    @NotEmpty
+    @JsonProperty
+    private String license = "";
+    
+    @NotEmpty
+    @JsonProperty
+    private String licenseUrl = "";
+
+    public String getRootServerName() {
+        return rootServerName;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getTermsOfServiceUrl() {
+        return termsOfServiceUrl;
+    }
+
+    public String getContact() {
+        return contact;
+    }
+
+    public String getLicense() {
+        return license;
+    }
+
+    public String getLicenseUrl() {
+        return licenseUrl;
+    }
+    
+}

--- a/src/main/java/com/hmsonline/dropwizard/spring/SpringServiceConfiguration.java
+++ b/src/main/java/com/hmsonline/dropwizard/spring/SpringServiceConfiguration.java
@@ -15,7 +15,7 @@ public class SpringServiceConfiguration extends Configuration {
     
     @NotNull
     @JsonProperty
-    private ApiMetadata apiMetadata;
+    private ApiMetadata apiMetadata = new ApiMetadata();
     
     public SpringConfiguration getSpring(){
         return this.spring;

--- a/src/main/java/com/hmsonline/dropwizard/spring/SpringServiceConfiguration.java
+++ b/src/main/java/com/hmsonline/dropwizard/spring/SpringServiceConfiguration.java
@@ -13,8 +13,16 @@ public class SpringServiceConfiguration extends Configuration {
     @JsonProperty
     private SpringConfiguration spring;
     
+    @NotNull
+    @JsonProperty
+    private ApiMetadata apiMetadata;
+    
     public SpringConfiguration getSpring(){
         return this.spring;
+    }
+    
+    public ApiMetadata getApiMetadata(){
+        return this.apiMetadata;
     }
 
 }


### PR DESCRIPTION
The added YAML fields are optional and can be used to help document the Dropwizard Spring application.
