### PR TITLE
Feature/dropwizard bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,34 @@ This is required to have maven build a "fat," executable jar file.
 	    configLocations:
 	       - conf/dropwizard-beans.xml
 
+		# Beans to be created from the configuration provided
+		# These will be constructed *before* the configLocations are parsed allowing their values to be used.
+		#
+		# Example below reflects this equivalent spring XML config:
+		#	<bean name="uniqueBeanNameHere" class="class.to.Construct">
+		#		<property name="key1" value="value1"/>
+		#		<property name="key2" value="1234"/>
+		#		<property name="key3" value="true"/>
+		#	</bean>
+		#	<bean name="remoteApi" class="com.myapp.config.RemoteAP">
+		#		<property name="url" value="http://api.domain.com/rest/v2/"/>
+		#		<property name="username" value="myuser"/>
+		#		<property name="password" value="some-password-hash"/>
+		#	</bean>
+		beans:
+			uniqueBeanNameHere:
+				clazz: class.to.Construct
+				config:
+					key1: "value1"
+					key2: 1234
+					key3: true
+			remoteApi:
+				clazz: com.myapp.config.RemoteAPI
+				config:
+					url: "http://api.domain.com/rest/v2/"
+					username: "myuser"
+					password: "some-password-hash"
+
         # Servlet Filter
         # List of FilterConfiguration
         filters:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ entirely with spring, and tell the spring service which components to enable usi
 With **dropwizard-spring** it is not necessary to subclass `com.yammer.dropwizard.Service`, instead you reference the provided 
 `com.hmsonline.dropwizard.spring.SpringService` class as  your service class.
 
+With **dropwizard-spring** 0.7+ it is possible to use your own `com.yammer.dropwizard.Service` (Application in dropwizard 0.7)
+and use the provided `com.hmsonline.dropwizard.spring.SpringBundle` class by adding `bootstrap.addBundle(new SpringBundle());`
+to the `initialize` method of your dropwizard Service/Application class. This allows you to subclass the SpringServiceConfiguration
+dropwizard Configuration object to add your own configuration settings, and also introduce your own logic into your
+dropwizard Service/Application.
 
 ## Maven Configuration
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.hmsonline</groupId>
 	<artifactId>dropwizard-spring</artifactId>
-	<version>0.6.2-SNAPSHOT</version>
+	<version>0.7.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>Spring Integration for DropWizard</description>
 	<url>https://github.com/hmsonline/dropwizard-spring</url>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<dropwizard.version>0.7.0</dropwizard.version>
 		<spring.version>3.2.8.RELEASE</spring.version>
+		<beanutils.version>1.7.0</beanutils.version>
 	</properties>
 
 	<scm>
@@ -67,6 +68,11 @@
             <artifactId>spring-web</artifactId>
             <version>${spring.version}</version>
         </dependency>
+		<dependency>
+			<groupId>commons-beanutils</groupId>
+			<artifactId>commons-beanutils</artifactId>
+			<version>${beanutils.version}</version>
+		</dependency>
         <dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/src/main/java/com/hmsonline/dropwizard/spring/BeanConfiguration.java
+++ b/src/main/java/com/hmsonline/dropwizard/spring/BeanConfiguration.java
@@ -1,0 +1,31 @@
+// Copyright (c) 2015 Hardiker Ltd.
+package com.hmsonline.dropwizard.spring;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+public class BeanConfiguration {
+
+    @JsonProperty
+    private String clazz; // Filter class.
+
+    @JsonProperty
+    private Map<String, Object> config; // Init params.
+
+    public String getClazz() {
+        return clazz;
+    }
+
+    public void setClazz(String clazz) {
+        this.clazz = clazz;
+    }
+
+    public Map<String, Object> getConfig() {
+        return config;
+    }
+
+    public void setConfig(Map<String, Object> config) {
+        this.config = config;
+    }
+}

--- a/src/main/java/com/hmsonline/dropwizard/spring/SpringBundle.java
+++ b/src/main/java/com/hmsonline/dropwizard/spring/SpringBundle.java
@@ -26,6 +26,7 @@ public class SpringBundle implements ConfiguredBundle<SpringServiceConfiguration
         SpringConfiguration config = configuration.getSpring();
 
         ApplicationContext parentCtx = initSpringParent();
+        parentCtx = wrapApplicationContext(parentCtx, config);
 
         Dropwizard dw = (Dropwizard) parentCtx.getBean("dropwizard");
         dw.setConfiguration(configuration);
@@ -50,6 +51,19 @@ public class SpringBundle implements ConfiguredBundle<SpringServiceConfiguration
 
         enableJerseyFeatures(config.getEnabledJerseyFeatures(), environment);
         disableJerseyFeatures(config.getDisabledJerseyFeatures(), environment);
+    }
+
+    /**
+     * This allows you to wrap the ApplicationContext, potentially with another ApplicationContext to extend the base
+     * functionality to meet your needs. Don't forget to refresh any new ApplicationContext's you create!
+     *
+     * @param parent Root Application Context
+     * @param config SpringConfiguration object for reference
+     * @return Application Context for further use
+     */
+    @SuppressWarnings("unused")
+    protected ApplicationContext wrapApplicationContext(ApplicationContext parent, SpringConfiguration config) {
+        return parent;
     }
 
     void loadWebConfigs(Environment environment, SpringConfiguration config, ApplicationContext appCtx) throws ClassNotFoundException {

--- a/src/main/java/com/hmsonline/dropwizard/spring/SpringBundle.java
+++ b/src/main/java/com/hmsonline/dropwizard/spring/SpringBundle.java
@@ -26,12 +26,12 @@ public class SpringBundle implements ConfiguredBundle<SpringServiceConfiguration
         SpringConfiguration config = configuration.getSpring();
 
         ApplicationContext parentCtx = initSpringParent();
-        parentCtx = wrapApplicationContext(parentCtx, config);
 
         Dropwizard dw = (Dropwizard) parentCtx.getBean("dropwizard");
         dw.setConfiguration(configuration);
         dw.setEnvironment(environment);
 
+        parentCtx = wrapApplicationContext(parentCtx, config);
         parentCtx = initSpringConfigBasedBeans(parentCtx, config);
 
         ApplicationContext appCtx = initSpring(config, parentCtx);

--- a/src/main/java/com/hmsonline/dropwizard/spring/SpringBundle.java
+++ b/src/main/java/com/hmsonline/dropwizard/spring/SpringBundle.java
@@ -8,8 +8,12 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import org.springframework.context.ApplicationContext;
 
+import java.util.List;
+
 
 public class SpringBundle implements ConfiguredBundle<SpringServiceConfiguration> {
+
+    SpringService service = new SpringService();
 
     @Override
     public void initialize(Bootstrap<?> bootstrap) {
@@ -21,32 +25,75 @@ public class SpringBundle implements ConfiguredBundle<SpringServiceConfiguration
     public void run(SpringServiceConfiguration configuration, Environment environment) {
         SpringConfiguration config = configuration.getSpring();
 
-        SpringService service = new SpringService();
-        ApplicationContext parentCtx = service.initSpringParent();
+        ApplicationContext parentCtx = initSpringParent();
 
         Dropwizard dw = (Dropwizard) parentCtx.getBean("dropwizard");
         dw.setConfiguration(configuration);
         dw.setEnvironment(environment);
 
-        ApplicationContext appCtx = service.initSpring(config, parentCtx);
-        service.loadResourceBeans(config.getResources(), appCtx, environment);
-        service.loadHealthCheckBeans(config.getHealthChecks(), appCtx, environment);
-        service.loadManagedBeans(config.getManaged(), appCtx, environment);
-        service.loadLifeCycleBeans(config.getLifeCycles(), appCtx, environment);
-        service.loadJerseyProviders(config.getJerseyProviders(), appCtx, environment);
-        service.loadTasks(config.getTasks(), appCtx, environment);
+        ApplicationContext appCtx = initSpring(config, parentCtx);
+        loadResourceBeans(config.getResources(), appCtx, environment);
+        loadHealthCheckBeans(config.getHealthChecks(), appCtx, environment);
+        loadManagedBeans(config.getManaged(), appCtx, environment);
+        loadLifeCycleBeans(config.getLifeCycles(), appCtx, environment);
+        loadJerseyProviders(config.getJerseyProviders(), appCtx, environment);
+        loadTasks(config.getTasks(), appCtx, environment);
 
         // Load filter or listeners for WebApplicationContext.
         if (appCtx instanceof XmlRestWebApplicationContext) {
             try {
-                service.loadWebConfigs(environment, config, appCtx);
+                loadWebConfigs(environment, config, appCtx);
             } catch (ClassNotFoundException e) {
                 throw new RuntimeException("CNFE when loading spring web configs: " + e.getMessage(), e);
             }
         }
 
-        service.enableJerseyFeatures(config.getEnabledJerseyFeatures(), environment);
-        service.disableJerseyFeatures(config.getDisabledJerseyFeatures(), environment);
+        enableJerseyFeatures(config.getEnabledJerseyFeatures(), environment);
+        disableJerseyFeatures(config.getDisabledJerseyFeatures(), environment);
+    }
+
+    void loadWebConfigs(Environment environment, SpringConfiguration config, ApplicationContext appCtx) throws ClassNotFoundException {
+        service.loadWebConfigs(environment, config, appCtx);
+    }
+
+    void loadResourceBeans(List<String> resources, ApplicationContext ctx, Environment env) {
+        service.loadResourceBeans(resources, ctx, env);
+    }
+
+    void loadHealthCheckBeans(List<String> healthChecks, ApplicationContext ctx, Environment env) {
+        service.loadHealthCheckBeans(healthChecks, ctx, env);
+    }
+
+    void loadManagedBeans(List<String> manageds, ApplicationContext ctx, Environment env) {
+        service.loadManagedBeans(manageds, ctx, env);
+    }
+
+    void loadLifeCycleBeans(List<String> lifeCycles, ApplicationContext ctx, Environment env) {
+        service.loadLifeCycleBeans(lifeCycles, ctx, env);
+    }
+
+    void loadJerseyProviders(List<String> providers, ApplicationContext ctx, Environment env) {
+        service.loadJerseyProviders(providers, ctx, env);
+    }
+
+    void loadTasks(List<String> tasks, ApplicationContext ctx, Environment env) {
+        service.loadTasks(tasks, ctx, env);
+    }
+
+    void enableJerseyFeatures(List<String> features, Environment env) {
+        service.enableJerseyFeatures(features, env);
+    }
+
+    void disableJerseyFeatures(List<String> features, Environment env) {
+        service.disableJerseyFeatures(features, env);
+    }
+
+    ApplicationContext initSpringParent() {
+        return service.initSpringParent();
+    }
+
+    ApplicationContext initSpring(SpringConfiguration config, ApplicationContext parent) {
+        return service.initSpring(config, parent);
     }
 
 }

--- a/src/main/java/com/hmsonline/dropwizard/spring/SpringBundle.java
+++ b/src/main/java/com/hmsonline/dropwizard/spring/SpringBundle.java
@@ -32,6 +32,8 @@ public class SpringBundle implements ConfiguredBundle<SpringServiceConfiguration
         dw.setConfiguration(configuration);
         dw.setEnvironment(environment);
 
+        parentCtx = initSpringConfigBasedBeans(parentCtx, config);
+
         ApplicationContext appCtx = initSpring(config, parentCtx);
         loadResourceBeans(config.getResources(), appCtx, environment);
         loadHealthCheckBeans(config.getHealthChecks(), appCtx, environment);
@@ -104,6 +106,10 @@ public class SpringBundle implements ConfiguredBundle<SpringServiceConfiguration
 
     ApplicationContext initSpringParent() {
         return service.initSpringParent();
+    }
+
+    ApplicationContext initSpringConfigBasedBeans(ApplicationContext parent, SpringConfiguration springConfiguration) {
+        return service.initSpringConfigBasedBeans(parent, springConfiguration);
     }
 
     ApplicationContext initSpring(SpringConfiguration config, ApplicationContext parent) {

--- a/src/main/java/com/hmsonline/dropwizard/spring/SpringBundle.java
+++ b/src/main/java/com/hmsonline/dropwizard/spring/SpringBundle.java
@@ -1,0 +1,52 @@
+// Copyright (c) 2015 Hardiker Ltd.
+package com.hmsonline.dropwizard.spring;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.hmsonline.dropwizard.spring.web.XmlRestWebApplicationContext;
+import io.dropwizard.ConfiguredBundle;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import org.springframework.context.ApplicationContext;
+
+
+public class SpringBundle implements ConfiguredBundle<SpringServiceConfiguration> {
+
+    @Override
+    public void initialize(Bootstrap<?> bootstrap) {
+        // This is needed to avoid an exception when deserializing Json to an ArrayList<String>
+        bootstrap.getObjectMapper().enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+    }
+
+    @Override
+    public void run(SpringServiceConfiguration configuration, Environment environment) {
+        SpringConfiguration config = configuration.getSpring();
+
+        SpringService service = new SpringService();
+        ApplicationContext parentCtx = service.initSpringParent();
+
+        Dropwizard dw = (Dropwizard) parentCtx.getBean("dropwizard");
+        dw.setConfiguration(configuration);
+        dw.setEnvironment(environment);
+
+        ApplicationContext appCtx = service.initSpring(config, parentCtx);
+        service.loadResourceBeans(config.getResources(), appCtx, environment);
+        service.loadHealthCheckBeans(config.getHealthChecks(), appCtx, environment);
+        service.loadManagedBeans(config.getManaged(), appCtx, environment);
+        service.loadLifeCycleBeans(config.getLifeCycles(), appCtx, environment);
+        service.loadJerseyProviders(config.getJerseyProviders(), appCtx, environment);
+        service.loadTasks(config.getTasks(), appCtx, environment);
+
+        // Load filter or listeners for WebApplicationContext.
+        if (appCtx instanceof XmlRestWebApplicationContext) {
+            try {
+                service.loadWebConfigs(environment, config, appCtx);
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException("CNFE when loading spring web configs: " + e.getMessage(), e);
+            }
+        }
+
+        service.enableJerseyFeatures(config.getEnabledJerseyFeatures(), environment);
+        service.disableJerseyFeatures(config.getDisabledJerseyFeatures(), environment);
+    }
+
+}

--- a/src/main/java/com/hmsonline/dropwizard/spring/SpringConfiguration.java
+++ b/src/main/java/com/hmsonline/dropwizard/spring/SpringConfiguration.java
@@ -1,4 +1,5 @@
 // Copyright (c) 2012 Health Market Science, Inc.
+// Extended by Hardiker Ltd
 
 package com.hmsonline.dropwizard.spring;
 
@@ -34,6 +35,9 @@ public class SpringConfiguration extends Configuration {
     @NotEmpty
     @JsonProperty
     private List<String> resources;
+
+    @JsonProperty
+    private Map<String, BeanConfiguration> beans;
 
     @JsonProperty
     private List<String> healthChecks;
@@ -73,6 +77,10 @@ public class SpringConfiguration extends Configuration {
 
     public List<String> getResources() {
         return resources;
+    }
+
+    public Map<String, BeanConfiguration> getBeans() {
+        return beans;
     }
 
     public List<String> getHealthChecks() {

--- a/src/main/java/com/hmsonline/dropwizard/spring/SpringService.java
+++ b/src/main/java/com/hmsonline/dropwizard/spring/SpringService.java
@@ -78,7 +78,7 @@ public class SpringService extends Application<SpringServiceConfiguration> {
     /**
      * Load filter, servlets or listeners for WebApplicationContext.
      */
-    private void loadWebConfigs(Environment environment, SpringConfiguration config, ApplicationContext appCtx) throws ClassNotFoundException {
+    void loadWebConfigs(Environment environment, SpringConfiguration config, ApplicationContext appCtx) throws ClassNotFoundException {
         // Load filters.
         loadFilters(config.getFilters(), environment);
 
@@ -93,7 +93,7 @@ public class SpringService extends Application<SpringServiceConfiguration> {
      * Load all filters.
      */
     @SuppressWarnings("unchecked")
-    private void loadFilters(Map<String, FilterConfiguration> filters, Environment environment) throws ClassNotFoundException {
+    void loadFilters(Map<String, FilterConfiguration> filters, Environment environment) throws ClassNotFoundException {
         if (filters != null) {
             for (Map.Entry<String, FilterConfiguration> filterEntry : filters.entrySet()) {
                 FilterConfiguration filter = filterEntry.getValue();
@@ -121,7 +121,7 @@ public class SpringService extends Application<SpringServiceConfiguration> {
      * Load all servlets.
      */
     @SuppressWarnings("unchecked")
-    private void loadServlets(Map<String, ServletConfiguration> servlets, Environment environment) throws ClassNotFoundException {
+    void loadServlets(Map<String, ServletConfiguration> servlets, Environment environment) throws ClassNotFoundException {
         if (servlets != null) {
             for (Map.Entry<String, ServletConfiguration> servletEntry : servlets.entrySet()) {
                 ServletConfiguration servlet = servletEntry.getValue();
@@ -145,7 +145,7 @@ public class SpringService extends Application<SpringServiceConfiguration> {
         }
     }
 
-    private void loadResourceBeans(List<String> resources, ApplicationContext ctx, Environment env) {
+    void loadResourceBeans(List<String> resources, ApplicationContext ctx, Environment env) {
         if (resources != null) {
             for (String resource : resources) {
                 try {
@@ -158,7 +158,7 @@ public class SpringService extends Application<SpringServiceConfiguration> {
 
     }
 
-    private void loadHealthCheckBeans(List<String> healthChecks, ApplicationContext ctx, Environment env) {
+    void loadHealthCheckBeans(List<String> healthChecks, ApplicationContext ctx, Environment env) {
         if (healthChecks != null) {
             for (String healthCheck : healthChecks) {
                 try {
@@ -171,7 +171,7 @@ public class SpringService extends Application<SpringServiceConfiguration> {
         }
     }
 
-    private void loadManagedBeans(List<String> manageds, ApplicationContext ctx, Environment env) {
+    void loadManagedBeans(List<String> manageds, ApplicationContext ctx, Environment env) {
         if (manageds != null) {
             for (String managed : manageds) {
                 try {
@@ -183,7 +183,7 @@ public class SpringService extends Application<SpringServiceConfiguration> {
         }
     }
 
-    private void loadLifeCycleBeans(List<String> lifeCycles, ApplicationContext ctx, Environment env) {
+    void loadLifeCycleBeans(List<String> lifeCycles, ApplicationContext ctx, Environment env) {
         if (lifeCycles != null) {
             for (String lifeCycle : lifeCycles) {
                 try {
@@ -195,7 +195,7 @@ public class SpringService extends Application<SpringServiceConfiguration> {
         }
     }
 
-    private void loadJerseyProviders(List<String> providers, ApplicationContext ctx, Environment env) {
+    void loadJerseyProviders(List<String> providers, ApplicationContext ctx, Environment env) {
         if (providers != null) {
             for (String provider : providers) {
                 try {
@@ -207,7 +207,7 @@ public class SpringService extends Application<SpringServiceConfiguration> {
         }
     }
 
-    private void loadTasks(List<String> tasks, ApplicationContext ctx, Environment env) {
+    void loadTasks(List<String> tasks, ApplicationContext ctx, Environment env) {
         if (tasks != null) {
             for (String task : tasks) {
                 try {
@@ -219,7 +219,7 @@ public class SpringService extends Application<SpringServiceConfiguration> {
         }
     }
 
-    private void enableJerseyFeatures(List<String> features, Environment env) {
+    void enableJerseyFeatures(List<String> features, Environment env) {
         if (features != null) {
             for (String feature : features) {
                 env.jersey().enable(feature);
@@ -227,7 +227,7 @@ public class SpringService extends Application<SpringServiceConfiguration> {
         }
     }
 
-    private void disableJerseyFeatures(List<String> features, Environment env) {
+    void disableJerseyFeatures(List<String> features, Environment env) {
         if (features != null) {
             for (String feature : features) {
                 env.jersey().disable(feature);
@@ -235,13 +235,13 @@ public class SpringService extends Application<SpringServiceConfiguration> {
         }
     }
 
-    private ApplicationContext initSpringParent() {
+    ApplicationContext initSpringParent() {
         ApplicationContext parent = new ClassPathXmlApplicationContext(
                 new String[]{"dropwizardSpringApplicationContext.xml"}, true);
         return parent;
     }
 
-    private ApplicationContext initSpring(SpringConfiguration config, ApplicationContext parent) {
+    ApplicationContext initSpring(SpringConfiguration config, ApplicationContext parent) {
         ApplicationContext appCtx = null;
         // Get Application Context Type
         String ctxType = config.getAppContextType();
@@ -269,7 +269,7 @@ public class SpringService extends Application<SpringServiceConfiguration> {
         return appCtx;
     }
 
-    private void logNoSuchBeanDefinitionException(NoSuchBeanDefinitionException nsbde) {
+    void logNoSuchBeanDefinitionException(NoSuchBeanDefinitionException nsbde) {
         if (LOG.isWarnEnabled()) {
             LOG.warn("Skipping missing Spring bean: ", nsbde);
         }


### PR DESCRIPTION
This comprises of 3 changes, all of which I needed to use this library with my dropwizard application.
1. Supporting dropwizard Bundles, which means you can add your own logic & configuration. The change could have been better (such as moving the config to an interface) but would have broken backward compatibility.
2. Extending the SpringConfiguration to allow beans to be created through the configuration.
3. Enabling the methods to be overridden if necessary through unofficial APIs, protection moving from private to package-local making minor extensions much simpler. As the code is single threaded, the risks here are limited.

The README.md has been updated with examples. I've released this into my private repository at 0.7.0 as it was a functional change.
