### PR TITLE
Added the ability to configure jersey properties via configuration

### DIFF
--- a/src/main/java/com/hmsonline/dropwizard/spring/SpringConfiguration.java
+++ b/src/main/java/com/hmsonline/dropwizard/spring/SpringConfiguration.java
@@ -50,12 +50,14 @@ public class SpringConfiguration extends Configuration {
     @JsonProperty
     private List<String> tasks;
 
-
     @JsonProperty
     private List<String> disabledJerseyFeatures;
 
     @JsonProperty
     private List<String> enabledJerseyFeatures;
+    
+    @JsonProperty
+    private Map<String, String> jerseyProperties;
 
     @JsonProperty
     private Map<String, FilterConfiguration> filters;
@@ -97,6 +99,10 @@ public class SpringConfiguration extends Configuration {
 
     public List<String> getEnabledJerseyFeatures() {
         return enabledJerseyFeatures;
+    }
+    
+    public Map<String, String> getJerseyProperties() {
+        return jerseyProperties;
     }
 
     public List<String> getTasks() {

--- a/src/main/java/com/hmsonline/dropwizard/spring/SpringService.java
+++ b/src/main/java/com/hmsonline/dropwizard/spring/SpringService.java
@@ -11,6 +11,7 @@ import com.hmsonline.dropwizard.spring.web.ServletConfiguration;
 import com.hmsonline.dropwizard.spring.web.XmlRestWebApplicationContext;
 import com.yammer.dropwizard.config.FilterBuilder;
 import com.yammer.dropwizard.config.ServletBuilder;
+
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -67,6 +68,8 @@ public class SpringService extends Service<SpringServiceConfiguration> {
         enableJerseyFeatures(config.getEnabledJerseyFeatures(), environment);
         disableJerseyFeatures(config.getDisabledJerseyFeatures(), environment);
 
+        setJerseyProperties(config.getJerseyProperties(), environment);
+        
     }
 
     /**
@@ -189,6 +192,14 @@ public class SpringService extends Service<SpringServiceConfiguration> {
         if (features != null) {
             for (String feature : features) {
                 env.disableJerseyFeature(feature);
+            }
+        }
+    }
+    
+    private void setJerseyProperties(Map<String, String> properties, Environment env) {
+        if (properties != null) {
+            for (Map.Entry<String, String> propertyEntry : properties.entrySet()) {
+                env.setJerseyProperty(propertyEntry.getKey(), propertyEntry.getValue());
             }
         }
     }


### PR DESCRIPTION
You can now specify something like this in the config.yaml:

``` yaml
    jerseyProperties:
      com.sun.jersey.spi.container.ContainerRequestFilters: com.hmsonline.sui.webservice.logging.LoggingFilter
      com.sun.jersey.spi.container.ContainerResponseFilters: com.hmsonline.sui.webservice.logging.LoggingFilter
```

This is a simple key/value map of properties set on the environment jersey properties.

This new property is not required.
