### PR TITLE
Added support for Spring Profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,11 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.4</version>
+		</dependency>
+		<dependency>
 			<groupId>com.yammer.dropwizard</groupId>
 			<artifactId>dropwizard-core</artifactId>
 			<version>${dropwizard.version}</version>

--- a/src/main/java/com/hmsonline/dropwizard/spring/SpringConfiguration.java
+++ b/src/main/java/com/hmsonline/dropwizard/spring/SpringConfiguration.java
@@ -64,6 +64,9 @@ public class SpringConfiguration extends Configuration {
 
     @JsonProperty
     private Map<String, ServletConfiguration> servlets;
+    
+    @JsonProperty
+    private List<String> profiles;
 
     public String getAppContextType() {
         return appContextType;
@@ -123,6 +126,14 @@ public class SpringConfiguration extends Configuration {
 
     public void setServlets(Map<String, ServletConfiguration> servlets) {
         this.servlets = servlets;
+    }
+
+    public List<String> getProfiles() {
+        return profiles;
+    }
+
+    public void setProfiles(List<String> profiles) {
+        this.profiles = profiles;
     }
 
     public String getConfigLocationsType() {

--- a/src/main/java/com/hmsonline/dropwizard/spring/SpringService.java
+++ b/src/main/java/com/hmsonline/dropwizard/spring/SpringService.java
@@ -12,6 +12,7 @@ import com.hmsonline.dropwizard.spring.web.XmlRestWebApplicationContext;
 import com.yammer.dropwizard.config.FilterBuilder;
 import com.yammer.dropwizard.config.ServletBuilder;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,6 +20,7 @@ import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.context.support.FileSystemXmlApplicationContext;
+import org.springframework.util.CollectionUtils;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.yammer.dropwizard.Service;
@@ -50,6 +52,8 @@ public class SpringService extends Service<SpringServiceConfiguration> {
     public void run(SpringServiceConfiguration configuration, Environment environment) throws ClassNotFoundException {
         SpringConfiguration config = configuration.getSpring();
 
+        setProfiles(config.getProfiles());
+        
         ApplicationContext parentCtx = this.initSpringParent();
 
         Dropwizard dw = (Dropwizard) parentCtx.getBean("dropwizard");
@@ -236,6 +240,14 @@ public class SpringService extends Service<SpringServiceConfiguration> {
         ApplicationContext parent = new ClassPathXmlApplicationContext(
                 new String[]{"dropwizardSpringApplicationContext.xml"}, true);
         return parent;
+    }
+    
+    private void setProfiles(List<String> profiles) {
+        if (CollectionUtils.isEmpty(profiles)) {
+            return;
+        }
+        
+        System.setProperty("spring.profiles.active", StringUtils.join(profiles, ","));
     }
 
     private ApplicationContext initSpring(SpringConfiguration config, ApplicationContext parent) {


### PR DESCRIPTION
Configuration goes in config.yaml in a new profiles section.

``` yaml
spring:
    profiles:
      - default
      - mock
```

This would cause beans with the mock or default profiles to be activated.

If I have this situation:

``` java
@Component
@Profile("mock")
public class FooMockImpl implements Foo {
   public void doWork() { }
}

@Component
@Profile("live")
public class FooImpl implements Foo {
   public void doWork() { }
}

public interface Foo {
   void doWork();
}

@Component
public class FooService {
   private Foo foo;

   @Autowired
   public FooService(Foo foo) {
      this.foo = foo;
   }
}
```

With the below settings in config.yaml FooMockImpl would be selected and injected by spring.

``` yaml
spring:
    profiles:
      - mock
```

With the below settings in config.yaml FooImpl would be selected and injected by spring.

``` yaml
spring:
    profiles:
      - live
```
